### PR TITLE
Fix HTML structure while preserving tracking

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,9 +33,9 @@
         t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}
       )(window,document,'script','https://connect.facebook.net/en_US/fbevents.js');
 
-      fbq('init','1108333617311057');                 
-      fbq('track','PageView');                        
-      fbq('track','ViewContent',{page:'pressell'});   
+      fbq('init','1108333617311057');
+      fbq('track','PageView');
+      fbq('track','ViewContent',{page:'pressell'});
     </script>
 
     <!-- Utmify Pixel -->
@@ -47,11 +47,26 @@
       a.setAttribute("src", "https://cdn.utmify.com.br/scripts/pixel/pixel.js");
       document.head.appendChild(a);
     </script>
-
+  </head>
+  <body>
+    <div class="wrap">
+      <div class="card">
+        <h1>Acesso Exclusivo</h1>
+        <p>Conteúdo exclusivo para membros. Entre para acessar.</p>
+        <div class="status">
+          <span class="dot"></span>
+          <span>Carregando</span>
+        </div>
+        <div class="bar"><div class="fill"></div></div>
+        <p class="hint">Você será redirecionado em instantes…</p>
+        <a class="cta" href="https://t.me/vazadosoficial00_bot">Entrar</a>
+      </div>
+    </div>
     <noscript>
       <img height="1" width="1" style="display:none"
            src="https://www.facebook.com/tr?id=1108333617311057&ev=PageView&noscript=1"/>
       <meta http-equiv="refresh" content="1.5;url=https://t.me/vazadosoficial00_bot">
     </noscript>
-  </head>
+  </body>
+</html>
 


### PR DESCRIPTION
## Summary
- Add missing body markup and card content
- Move noscript fallback into body to avoid invalid HTML

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68a6ffd5d3b4833192addd9aa301f7c8